### PR TITLE
BUG - Change render locations of HubCare elements on GitHub

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -1,3 +1,4 @@
+import * as $ from 'jquery';
 import echarts from 'echarts/lib/echarts';
 import 'echarts/lib/chart/line';
 import 'echarts/lib/component/tooltip';
@@ -124,12 +125,13 @@ const init = () => {
     insertActivityIndicator()
     insertButton()
     requestMetrics()
+    document.getElementById('hubcare-button').addEventListener("click", function() {
+        cleanPageContent()
+    }, false);
 }
 
 init()
 
-var hubbutton = document.getElementById('hubcare-button');
-hubbutton.addEventListener("click", function() {
-    console.log('test');
-    cleanPageContent()
-}, false);
+$(document).on('pjax:complete', () => {
+    init()
+});

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "badge": "^1.0.3",
     "badges": "^1.3.0",
     "echarts": "^4.2.1",
+    "jquery": "^3.4.1",
     "project-badge": "^0.2.0",
     "project-package": "0.0.1",
-    "zip-folder": "^1.0.0",
-    "spin.js": "^4.0.0"
+    "spin.js": "^4.0.0",
+    "zip-folder": "^1.0.0"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue #37 
<!-- Link the pull request's respective issue -->

## Description
<!--- Describe your changes in detail -->
A function was created using PJAX, so you can reload the Github page each time you click a button.
In this function using PJAX, Init () is loaded into it.
In the init (), the Badges and the 'Hubcare' button are inserted.
Clicking on the 'Hubcare' button deletes the content of the page.

## Screenshots (if appropriate):
<!--- You may want to show a new page functionality, for example -->
<!--- If not appropriate, just delete this topic -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!--- Do you wanna make your experience funnier? Try make your pull request with a selfie!! :) -->

<!--- You can check the selfie plugin in https://github.com/thieman/github-selfies -->
