### PR TITLE
47 save badges on variables and avoid unnecessary reload

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -12,9 +12,11 @@ const repoName = window.location.pathname
 
 var content = saveClass("new-discussion-timeline experiment-repo-nav")
 var repoContent = saveClass("repository-content")
-var active_var = null
-var support_var = null
-var welcoming_var = null
+var metrics = [{
+    active_indicator: null,
+    welcoming_indicator: null,
+    support_indicator: null
+}]
 var popup_key = ""
 
 chrome.storage.sync.get("active", function(res) {
@@ -100,13 +102,9 @@ const insertActivityIndicator = () => {
  * @param {json} data
  */
 const insertBadges = (data) => {
-    console.log(data)
-    active_var = data.active_indicator
-    support_var = data.support_indicator
-    welcoming_var = data.welcoming_indicator
-    console.log(active_var)
-    console.log(support_var)
-    console.log(welcoming_var)
+    metrics[0].active_indicator = data.active_indicator
+    metrics[0].support_indicator = data.support_indicator
+    metrics[0].welcoming_indicator = data.welcoming_indicator
     stopActivityIndicator()
     const node = document.createElement('div')
     node.innerHTML = badges()
@@ -179,6 +177,24 @@ const init = () => {
         insertButton()
         requestMetrics()
         buttonOnClick()
+        document.getElementById('hubcare-button').addEventListener("click", function() {
+            hubcarePage()
+        }, false);
+    }
+}
+
+/**
+ * Init all plugin elements, but with no request
+ */
+const init_with_no_request = () => {
+    if(popup_key != false){
+        if(window.location.hash ==  '#hubcare'){
+            hubcarePage()
+        }
+        insertActivityIndicator()
+        insertButton()
+        insertBadges(metrics[0])
+        buttonOnClick()
 
         document.getElementById('hubcare-button').addEventListener("click", function() {
             hubcarePage()
@@ -194,5 +210,10 @@ const hubcarePage = () => {
 //init()
 
 $(document).on('pjax:complete', () => {
-    init()
+    if(metrics[0].active_indicator == null){
+        init()
+    }
+    else {
+        init_with_no_request()
+    }
 })

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -12,6 +12,9 @@ const repoName = window.location.pathname
 
 var content = saveClass("new-discussion-timeline experiment-repo-nav")
 var repoContent = saveClass("repository-content")
+var active_var = null
+var support_var = null
+var welcoming_var = null
 var popup_key = ""
 
 chrome.storage.sync.get("active", function(res) {
@@ -97,6 +100,13 @@ const insertActivityIndicator = () => {
  * @param {json} data
  */
 const insertBadges = (data) => {
+    console.log(data)
+    active_var = data.active_indicator
+    support_var = data.support_indicator
+    welcoming_var = data.welcoming_indicator
+    console.log(active_var)
+    console.log(support_var)
+    console.log(welcoming_var)
     stopActivityIndicator()
     const node = document.createElement('div')
     node.innerHTML = badges()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue #47 
<!-- Link the pull request's respective issue -->

## Description
<!--- Describe your changes in detail -->
The app save the results in a variable, so it doesn't need to retrieve data from API again.

Only the first time the request is performed and it is saved in the global json at the time that it inserts the values ​​in the badges

Then pressing on another button already takes the global json metrics

## Screenshots (if appropriate):
<!--- You may want to show a new page functionality, for example -->
<!--- If not appropriate, just delete this topic -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!--- Do you wanna make your experience funnier? Try make your pull request with a selfie!! :) -->

<!--- You can check the selfie plugin in https://github.com/thieman/github-selfies -->
